### PR TITLE
Add Keylock and Quantize buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,4 @@ Drop the `Pioneered` folder in `<MIXXX_FOLDER>/skins` and select it from `Prefer
 ## Contributors
 * [timewasternl](https://github.com/timewasternl)
 * [GorgiAstro](https://github.com/GorgiAstro)
+* [BvOBart](https://github.com/bvobart)

--- a/icons/ReadMe.md
+++ b/icons/ReadMe.md
@@ -1,0 +1,3 @@
+# Pioneered Icons
+
+Keylock and Quantize icons were sourced from the Deere theme, included in Mixxx's default installation.

--- a/icons/keylock.svg
+++ b/icons/keylock.svg
@@ -1,0 +1,1 @@
+<svg id="svg2" version="1.1" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg"><path id="path4" d="m0 0h48v48h-48z" fill="none"/><path id="path6" d="m26 6v23.535c-1.648-0.986-3.785-1.533-6-1.535-4.9706 0-9 2.6863-9 6s4.0294 6 9 6 9-2.6863 9-6v-22l9 2v-6l-9-2z" fill="#d2d2d2"/></svg>

--- a/icons/quantize.svg
+++ b/icons/quantize.svg
@@ -1,0 +1,1 @@
+<svg id="svg2" version="1.1" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg"><path id="path4" d="m36 10v6h4v-6zm-12 0.031c-8.333 0-16 6.058-16 13.969 1e-4 7.9122 7.667 14.003 16 14h9v-6h-9c-5.494 0-10-3.7367-10-8 0-4.2623 4.506-8 10-8h9v-6zm12 21.969v6h4v-6z" fill="#d2d2d2"/><path id="path6" d="m0 0h48v48h-48z" fill="none"/></svg>

--- a/install.linux.sh
+++ b/install.linux.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Installs this Pioneered skin to ~/.mixxx/skins
+
+# Exit on first error
+set -e
+
+mkdir -p ~/.mixxx/skins
+[[ -d ~/.mixxx/skins/Pioneered ]] && rm -rf ~/.mixxx/skins/Pioneered
+cp -r $(dirname $0) ~/.mixxx/skins/Pioneered

--- a/style.qss
+++ b/style.qss
@@ -17,6 +17,10 @@ White: #e5e6ea
 }
 /* END */
 
+#Mixxx {
+  background-color: black;
+}
+
 * {
   font-family: 'Open Sans', sans-serif;
 }
@@ -29,6 +33,38 @@ QMenuBar, QMenuBar::item, QMenu, QMenu::item {
 QMenuBar::item:pressed, QMenu::item:selected, QMenu::item:pressed {
     background-color: rgba(255,255,255,0.2);
 }
+
+/************************************************************************/
+/*     Buttons                                                          */
+/************************************************************************/
+
+WPushButton {
+  color: #e5e6ea;
+  background-color: transparent;
+  border: 1px solid #32323c;
+  border-radius: 2px;
+  outline: none;
+}
+
+WPushButton:hover {
+  border: 1px solid #5F5F5F;
+}
+
+WPushButton[value="1"] {
+  color: #e5e6ea;
+  border: 1px solid #5F5F5F;
+  background-color: #32323c;
+}
+
+WPushButton[value="1"]:hover {
+  border: 1px solid #4B4B4B;
+  background-color: #30303a;
+}
+
+/************************************************************************/
+/*     Deck                                                             */
+/************************************************************************/
+
 
 #Deck {
   border: 1px solid transparent;
@@ -66,8 +102,16 @@ QMenuBar::item:pressed, QMenu::item:selected, QMenu::item:pressed {
   padding: 2px;
 }
 
+#DeckOverview {
+  margin: 50% 0;
+}
+
 #DeckTitle, #DeckTitleNote {
   font-size: 20px;
+}
+
+#DeckTitleNote {
+  margin: 0 2px;
 }
 
 #DeckChannelTitle, #DeckTrackTimeTitle, #DeckTempoTitle {
@@ -107,6 +151,10 @@ QMenuBar::item:pressed, QMenu::item:selected, QMenu::item:pressed {
   qproperty-layoutAlignment: 'AlignHCenter | AlignTop';
 }
 
+/************************************************************************/
+/*     Effects                                                          */
+/************************************************************************/
+
 WEffectSelector {
   background-color: transparent;
   color: #2d85cd;
@@ -140,13 +188,9 @@ WEffectSelector {
   font-weight: bold;
 }
 
-#DeckTitleNote {
-  margin: 0 2px;
-}
-
-#DeckOverview {
-  margin: 50% 0;
-}
+/************************************************************************/
+/*     Library                                                          */
+/************************************************************************/
 
 #LibraryWrapper QScrollBar {
   background-color: gray;
@@ -212,13 +256,23 @@ WEffectSelector {
   color: #e5e6ea;
 }
 
-#Mixxx {
-  background-color: black;
-}
-
 WLabel {
   color: #e5e6ea;
 }
+
+/* Library Search */
+#SearchBox {
+  background-color: #112f5c;
+  border-radius: 0;
+  font-size: 20px;
+  font-weight: bold;
+  padding: 4px;
+  text-transform: uppercase;
+}
+
+/************************************************************************/
+/*     BeatFX                                                           */
+/************************************************************************/
 
 #BeatFX_Container {
   border: 2px solid #32323c;
@@ -236,39 +290,6 @@ WLabel {
   text-transform: uppercase;
 }
 
-#Sampler {
-  background-color: #32323c;
-  border: 2px solid #d73535;
-  border-radius: 2px;
-  color: white;
-  font-size: 24px;
-  margin: 4px;
-  padding: 2px;
-}
-
-#Sampler[value="1"] {
-  background-color: #d73535;
-}
-
-#Sampler_Info {
-  color: white;
-  font-size: 10px;
-  margin: 4px;
-}
-
-#SamplersDeck1, #SamplersDeck2 {
-  margin: 0 4px;
-}
-
-#SearchBox {
-  background-color: #112f5c;
-  border-radius: 0;
-  font-size: 20px;
-  font-weight: bold;
-  padding: 4px;
-  text-transform: uppercase;
-}
-
 #SidebarContainer {
   background-color: #112f5c;
 }
@@ -282,6 +303,10 @@ WLabel {
   font-weight: bold;
   margin: 4px;
 }
+
+/************************************************************************/
+/*     Waveforms                                                        */
+/************************************************************************/
 
 #WaveformInfo {
   margin-right: 10px;
@@ -319,6 +344,18 @@ WLabel {
   padding: -6px -6px -3px -2px;
 }
 
+#WaveformInfo_KeylockButton {
+  image: url(skin:icons/keylock.svg) no-repeat center center;
+}
+
+#WaveformInfo_QuantizeButton {
+  image: url(skin:icons/quantize.svg) no-repeat center center;
+}
+
+/************************************************************************/
+/*     Tabs                                                             */
+/************************************************************************/
+
 #TabControls WPushButton {
   background-color: black;
   font-weight: bold;
@@ -335,4 +372,32 @@ WLabel {
 #TabControls WPushButton[value="1"] {
   border: 2px solid #c3d541;
   color: #c3d541;
+}
+
+/************************************************************************/
+/*     Samplers                                                         */
+/************************************************************************/
+
+#Sampler {
+  background-color: #32323c;
+  border: 2px solid #d73535;
+  border-radius: 2px;
+  color: white;
+  font-size: 24px;
+  margin: 4px;
+  padding: 2px;
+}
+
+#Sampler[value="1"] {
+  background-color: #d73535;
+}
+
+#Sampler_Info {
+  color: white;
+  font-size: 10px;
+  margin: 4px;
+}
+
+#SamplersDeck1, #SamplersDeck2 {
+  margin: 0 4px;
 }

--- a/templates/toggle_button.xml
+++ b/templates/toggle_button.xml
@@ -1,0 +1,38 @@
+<!DOCTYPE template>
+<!--
+  Description:
+    A button that has a left-click display control and a right-click control.
+  Variables:
+    ObjectName: The object name.
+    Size: the button size.
+    StateXText:
+    StateXPressed:
+    StateXUnpressed:
+
+Originally taken from the Deere theme included with Mixxx, modified slightly.
+-->
+<Template>
+  <PushButton>
+    <TooltipId><Variable name="TooltipId"/></TooltipId>
+    <ObjectName><Variable name="ObjectName"/></ObjectName>
+    <Size><Variable name="Size"/></Size>
+    <NumberStates>2</NumberStates>
+    <State>
+      <Number>0</Number>
+      <Text><Variable name="State0Text"/></Text>
+      <Pressed scalemode="STRETCH_ASPECT"><Variable name="State0Pressed"/></Pressed>
+      <Unpressed scalemode="STRETCH_ASPECT"><Variable name="State0Unpressed"/></Unpressed>
+    </State>
+    <State>
+      <Number>1</Number>
+      <Text><Variable name="State1Text"/></Text>
+      <Pressed scalemode="STRETCH_ASPECT"><Variable name="State1Pressed"/></Pressed>
+      <Unpressed scalemode="STRETCH_ASPECT"><Variable name="State1Unpressed"/></Unpressed>
+    </State>
+    <Connection>
+      <ConfigKey><Variable name="LeftConnectionControl"/></ConfigKey>
+      <EmitOnPressAndRelease>true</EmitOnPressAndRelease>
+      <ButtonState>LeftButton</ButtonState>
+    </Connection>
+  </PushButton>
+</Template>

--- a/waveform.xml
+++ b/waveform.xml
@@ -4,11 +4,13 @@
     <Layout>horizontal</Layout>
     <Size>0me,50me</Size>
     <Children>
+
       <WidgetGroup>
         <ObjectName>WaveformInfo</ObjectName>
         <Layout>vertical</Layout>
         <Size>100f,0me</Size>
         <Children>
+
           <WidgetGroup>
             <ObjectName>WaveformInfo_Header</ObjectName>
             <Layout>horizontal</Layout>
@@ -24,21 +26,25 @@
               <BindProperty>highlight</BindProperty>
             </Connection>
           </WidgetGroup>
+
           <WidgetGroup>
             <ObjectName>WaveformInfo_Data_Container</ObjectName>
             <Layout>vertical</Layout>
-            <Size>0me,25me</Size>
+            <Size>0me,90me</Size>
             <Children>
+
               <WidgetGroup>
                 <ObjectName>WaveformInfo_Key_Container</ObjectName>
                 <Layout>horizontal</Layout>
                 <Size>0me,30f</Size>
                 <Children>
+
                   <Label>
                     <ObjectName>WaveformInfo_Key_Icon</ObjectName>
                     <Text>&#9837;&#9839;</Text>
                     <Style>color: black;</Style>
                   </Label>
+
                   <Key>
                     <ObjectName>WaveformInfo_Key</ObjectName>
                     <TooltipId>visual_key</TooltipId>
@@ -46,8 +52,10 @@
                       <ConfigKey>[Channel<Variable name="channel"/>],visual_key</ConfigKey>
                     </Connection>
                   </Key>
+
                 </Children>
               </WidgetGroup>
+
               <WidgetGroup>
                 <ObjectName>WaveformInfo_Bars_Container</ObjectName>
                 <Layout>horizontal</Layout>
@@ -59,10 +67,36 @@
                   </Label>
                 </Children>
               </WidgetGroup>
+
+              <WidgetGroup>
+                <ObjectName>WaveformInfo_Controls</ObjectName>
+                <Layout>horizontal</Layout>
+                <Size>0me,30f</Size>
+                <Children>
+
+                  <Template src="skin:templates/toggle_button.xml">
+                    <SetVariable name="TooltipId">quantize</SetVariable>
+                    <SetVariable name="ObjectName">WaveformInfo_QuantizeButton</SetVariable>
+                    <SetVariable name="Size">30me,30f</SetVariable>
+                    <SetVariable name="LeftConnectionControl">[Channel<Variable name="channel"/>],quantize</SetVariable>
+                  </Template>
+
+                  <Template src="skin:templates/toggle_button.xml">
+                    <SetVariable name="TooltipId">keylock</SetVariable>
+                    <SetVariable name="ObjectName">WaveformInfo_KeylockButton</SetVariable>
+                    <SetVariable name="Size">30me,30f</SetVariable>
+                    <SetVariable name="LeftConnectionControl">[Channel<Variable name="channel"/>],keylock</SetVariable>
+                  </Template>
+
+                </Children>
+              </WidgetGroup>
+
             </Children>
           </WidgetGroup>
+
         </Children>
       </WidgetGroup>
+
       <Visual>
         <TooltipId>waveform_display</TooltipId>
         <ObjectName>Waveform<Variable name="channel"/></ObjectName>
@@ -105,6 +139,7 @@
           <DisabledOpacity>0.4</DisabledOpacity>
         </MarkRange>
       </Visual>
+
     </Children>
   </WidgetGroup>
 </Template>


### PR DESCRIPTION
Hi Sven @timewasternl ,

I saw your video on YouTube about your Raspberry Pi + DDJ-400 setup and got inspired, given that I also own a DDJ-400 and have been DJ-ing with Mixxx as I daily drive Linux :) So I bought myself a Raspberry Pi, touchscreen and some other stuff (SmartiPi Touch Pro case is coming soon, delayed to to production issues) and set it up with Manjaro, Mixxx and your Pioneered skin (I looked around but there was no other skin that's as comfortable as this one for DJ-ing on the RPi's touchscreen). It's working surprisingly well, already played two small house parties with it :P

I'd like to help continue the development of this skin. I've added two buttons, for toggling the keylock and quantize settings. I'm new to Mixxx skin development, so I took heavy inspiration from how Mixxx's Deere skin implements them. The buttons came out looking (and working) nice though :)

P.S. ik ben ook Nederlands :P