### PR TITLE
Hotcue and advanced effects

### DIFF
--- a/beffect.xml
+++ b/beffect.xml
@@ -1,0 +1,41 @@
+<Template>
+  <WidgetGroup>
+    <Layout>vertical</Layout>
+     <Children>
+                  <EffectChainPresetSelector>
+                    <ObjectName>EffectUnit1_kEffectSelectorLeft</ObjectName>
+                    <EffectUnitGroup>[EffectRack1_EffectUnit1]</EffectUnitGroup>
+                  </EffectChainPresetSelector>
+                <Connection>
+                  <ConfigKey persist="true">[Skin],show_eq_knobs</ConfigKey>
+                  <BindProperty>visible</BindProperty>
+                </Connection>
+<PushButton>
+        <ObjectName>EffectToggle</ObjectName>
+        <Size>0me,25max</Size>
+        <NumberStates>2</NumberStates>
+        <State>
+          <Number>0</Number>
+          <Text>Off</Text>
+        </State>
+        <State>
+          <Number>1</Number>
+          <Text>Active</Text>
+        </State>
+        <Connection>
+          <ConfigKey>[EffectRack<Variable name="rack"/>_EffectUnit<Variable name="unit"/>_Effect<Variable name="effect"/>],enabled</ConfigKey>
+          <ConnectValueToWidget>true</ConnectValueToWidget>
+        </Connection>
+        <Connection>
+          <ConfigKey>EffectRack<Variable name="rack"/>_EffectUnit<Variable name="unit"/>],group_[Master]_enable</ConfigKey>
+          <ConnectValueToWidget>false</ConnectValueToWidget>
+        </Connection>
+        <Connection>
+          <ConfigKey>[EffectRack<Variable name="rack"/>_EffectUnit<Variable name="unit"/>_Effect<Variable name="effect"/>],meta</ConfigKey>
+          <ConnectValueToWidget>false</ConnectValueToWidget>
+        </Connection>
+      </PushButton>
+
+    </Children>
+  </WidgetGroup>
+</Template>

--- a/ceffectl.xml
+++ b/ceffectl.xml
@@ -1,0 +1,15 @@
+<Template>
+  <WidgetGroup>
+    <Layout>vertical</Layout>
+     <Children>
+                  <EffectChainPresetSelector>
+                    <ObjectName>QuickEffectSelectorLeft</ObjectName>
+                    <EffectUnitGroup>[QuickEffectRack1_[Channel1]]</EffectUnitGroup>
+                  </EffectChainPresetSelector>
+                <Connection>
+                  <ConfigKey persist="true">[Skin],show_eq_knobs</ConfigKey>
+                  <BindProperty>visible</BindProperty>
+                </Connection>
+    </Children>
+  </WidgetGroup>
+</Template>

--- a/ceffectr.xml
+++ b/ceffectr.xml
@@ -1,0 +1,15 @@
+<Template>
+  <WidgetGroup>
+    <Layout>vertical</Layout>
+     <Children>
+                  <EffectChainPresetSelector>
+                    <ObjectName>QuickEffectSelectorLeft</ObjectName>
+                    <EffectUnitGroup>[QuickEffectRack1_[Channel2]]</EffectUnitGroup>
+                  </EffectChainPresetSelector>
+                <Connection>
+                  <ConfigKey persist="true">[Skin],show_eq_knobs</ConfigKey>
+                  <BindProperty>visible</BindProperty>
+                </Connection>
+    </Children>
+  </WidgetGroup>
+</Template>

--- a/deck.xml
+++ b/deck.xml
@@ -231,6 +231,38 @@
               <Control>cue_point</Control>
               <Color>#eb870f</Color>
             </Mark>
+	    <Mark>
+              <Control>hotcue_1_position</Control>
+              <Color>#eb870f</Color>
+            </Mark>
+            <Mark>
+              <Control>hotcue_2_position</Control>
+              <Color>#eb870f</Color>
+            </Mark>
+            <Mark>
+              <Control>hotcue_3_position</Control>
+              <Color>#eb870f</Color>
+            </Mark>
+            <Mark>
+              <Control>hotcue_4_position</Control>
+              <Color>#eb870f</Color>
+            </Mark>
+            <Mark>
+              <Control>hotcue_5_position</Control>
+              <Color>#eb870f</Color>
+            </Mark>
+            <Mark>
+              <Control>hotcue_6_position</Control>
+              <Color>#eb870f</Color>
+            </Mark>
+            <Mark>
+              <Control>hotcue_7_position</Control>
+              <Color>#eb870f</Color>
+            </Mark>
+            <Mark>
+              <Control>hotcue_8_position</Control>
+              <Color>#eb870f</Color>
+            </Mark>
             <Mark>
               <Control>loop_start_position</Control>
               <Color>#6ee128</Color>

--- a/overview.xml
+++ b/overview.xml
@@ -29,7 +29,39 @@
               <WidgetGroup>
                 <ObjectName>BeatFX_Header</ObjectName>
                 <Layout>horizontal</Layout>
-                <Size>0me,25p</Size>
+                <Size>0me,10p</Size>
+                <Children>
+                  <Label>
+                    <ObjectName>BeatFX_Title</ObjectName>
+                    <Text>Color FX L</Text>
+                  </Label>
+                </Children>
+              </WidgetGroup>
+               <Template src="skin:ceffectl.xml">
+                <SetVariable name="rack">1</SetVariable>
+                <SetVariable name="unit">1</SetVariable>
+                <SetVariable name="effect">1</SetVariable>
+              </Template>
+              <WidgetGroup>
+                <ObjectName>BeatFX_Header</ObjectName>
+                <Layout>horizontal</Layout>
+                <Size>0me,10p</Size>
+                <Children>
+                  <Label>
+                    <ObjectName>BeatFX_Title</ObjectName>
+                    <Text>Color FX R</Text>
+                  </Label>
+                </Children>
+              </WidgetGroup>
+               <Template src="skin:ceffectr.xml">
+                <SetVariable name="rack">1</SetVariable>
+                <SetVariable name="unit">1</SetVariable>
+                <SetVariable name="effect">1</SetVariable>
+              </Template>
+ 	      <WidgetGroup>
+                <ObjectName>BeatFX_Header</ObjectName>
+                <Layout>horizontal</Layout>
+                <Size>20me,10p</Size>
                 <Children>
                   <Label>
                     <ObjectName>BeatFX_Title</ObjectName>
@@ -37,7 +69,7 @@
                   </Label>
                 </Children>
               </WidgetGroup>
-              <Template src="skin:effect.xml">
+              <Template src="skin:beffect.xml">
                 <SetVariable name="rack">1</SetVariable>
                 <SetVariable name="unit">1</SetVariable>
                 <SetVariable name="effect">1</SetVariable>

--- a/style.qss
+++ b/style.qss
@@ -17,6 +17,10 @@ White: #e5e6ea
 }
 /* END */
 
+#Mixxx {
+  background-color: black;
+}
+
 * {
   font-family: 'Open Sans', sans-serif;
 }
@@ -29,6 +33,38 @@ QMenuBar, QMenuBar::item, QMenu, QMenu::item {
 QMenuBar::item:pressed, QMenu::item:selected, QMenu::item:pressed {
     background-color: rgba(255,255,255,0.2);
 }
+
+/************************************************************************/
+/*     Buttons                                                          */
+/************************************************************************/
+
+WPushButton {
+  color: #e5e6ea;
+  background-color: transparent;
+  border: 1px solid #32323c;
+  border-radius: 2px;
+  outline: none;
+}
+
+WPushButton:hover {
+  border: 1px solid #5F5F5F;
+}
+
+WPushButton[value="1"] {
+  color: #e5e6ea;
+  border: 1px solid #5F5F5F;
+  background-color: #32323c;
+}
+
+WPushButton[value="1"]:hover {
+  border: 1px solid #4B4B4B;
+  background-color: #30303a;
+}
+
+/************************************************************************/
+/*     Deck                                                             */
+/************************************************************************/
+
 
 #Deck {
   border: 1px solid transparent;
@@ -66,8 +102,16 @@ QMenuBar::item:pressed, QMenu::item:selected, QMenu::item:pressed {
   padding: 2px;
 }
 
+#DeckOverview {
+  margin: 50% 0;
+}
+
 #DeckTitle, #DeckTitleNote {
   font-size: 20px;
+}
+
+#DeckTitleNote {
+  margin: 0 2px;
 }
 
 #DeckChannelTitle, #DeckTrackTimeTitle, #DeckTempoTitle {
@@ -107,6 +151,10 @@ QMenuBar::item:pressed, QMenu::item:selected, QMenu::item:pressed {
   qproperty-layoutAlignment: 'AlignHCenter | AlignTop';
 }
 
+/************************************************************************/
+/*     Effects                                                          */
+/************************************************************************/
+
 WEffectChainPresetSelector {
   background-color: transparent;
   color: #2d85cd;
@@ -140,13 +188,9 @@ WEffectChainPresetSelector {
   font-weight: bold;
 }
 
-#DeckTitleNote {
-  margin: 0 2px;
-}
-
-#DeckOverview {
-  margin: 50% 0;
-}
+/************************************************************************/
+/*     Library                                                          */
+/************************************************************************/
 
 #LibraryWrapper QScrollBar {
   background-color: gray;
@@ -212,13 +256,23 @@ WEffectChainPresetSelector {
   color: #e5e6ea;
 }
 
-#Mixxx {
-  background-color: black;
-}
-
 WLabel {
   color: #e5e6ea;
 }
+
+/* Library Search */
+#SearchBox {
+  background-color: #112f5c;
+  border-radius: 0;
+  font-size: 20px;
+  font-weight: bold;
+  padding: 4px;
+  text-transform: uppercase;
+}
+
+/************************************************************************/
+/*     BeatFX                                                           */
+/************************************************************************/
 
 #BeatFX_Container {
   border: 2px solid #32323c;
@@ -236,39 +290,6 @@ WLabel {
   text-transform: uppercase;
 }
 
-#Sampler {
-  background-color: #32323c;
-  border: 2px solid #d73535;
-  border-radius: 2px;
-  color: white;
-  font-size: 24px;
-  margin: 4px;
-  padding: 2px;
-}
-
-#Sampler[value="1"] {
-  background-color: #d73535;
-}
-
-#Sampler_Info {
-  color: white;
-  font-size: 10px;
-  margin: 4px;
-}
-
-#SamplersDeck1, #SamplersDeck2 {
-  margin: 0 4px;
-}
-
-#SearchBox {
-  background-color: #112f5c;
-  border-radius: 0;
-  font-size: 20px;
-  font-weight: bold;
-  padding: 4px;
-  text-transform: uppercase;
-}
-
 #SidebarContainer {
   background-color: #112f5c;
 }
@@ -282,6 +303,10 @@ WLabel {
   font-weight: bold;
   margin: 4px;
 }
+
+/************************************************************************/
+/*     Waveforms                                                        */
+/************************************************************************/
 
 #WaveformInfo {
   margin-right: 10px;
@@ -319,6 +344,18 @@ WLabel {
   padding: -6px -6px -3px -2px;
 }
 
+#WaveformInfo_KeylockButton {
+  image: url(skin:icons/keylock.svg) no-repeat center center;
+}
+
+#WaveformInfo_QuantizeButton {
+  image: url(skin:icons/quantize.svg) no-repeat center center;
+}
+
+/************************************************************************/
+/*     Tabs                                                             */
+/************************************************************************/
+
 #TabControls WPushButton {
   background-color: black;
   font-weight: bold;
@@ -335,4 +372,32 @@ WLabel {
 #TabControls WPushButton[value="1"] {
   border: 2px solid #c3d541;
   color: #c3d541;
+}
+
+/************************************************************************/
+/*     Samplers                                                         */
+/************************************************************************/
+
+#Sampler {
+  background-color: #32323c;
+  border: 2px solid #d73535;
+  border-radius: 2px;
+  color: white;
+  font-size: 24px;
+  margin: 4px;
+  padding: 2px;
+}
+
+#Sampler[value="1"] {
+  background-color: #d73535;
+}
+
+#Sampler_Info {
+  color: white;
+  font-size: 10px;
+  margin: 4px;
+}
+
+#SamplersDeck1, #SamplersDeck2 {
+  margin: 0 4px;
 }

--- a/style.qss
+++ b/style.qss
@@ -17,10 +17,6 @@ White: #e5e6ea
 }
 /* END */
 
-#Mixxx {
-  background-color: black;
-}
-
 * {
   font-family: 'Open Sans', sans-serif;
 }
@@ -33,38 +29,6 @@ QMenuBar, QMenuBar::item, QMenu, QMenu::item {
 QMenuBar::item:pressed, QMenu::item:selected, QMenu::item:pressed {
     background-color: rgba(255,255,255,0.2);
 }
-
-/************************************************************************/
-/*     Buttons                                                          */
-/************************************************************************/
-
-WPushButton {
-  color: #e5e6ea;
-  background-color: transparent;
-  border: 1px solid #32323c;
-  border-radius: 2px;
-  outline: none;
-}
-
-WPushButton:hover {
-  border: 1px solid #5F5F5F;
-}
-
-WPushButton[value="1"] {
-  color: #e5e6ea;
-  border: 1px solid #5F5F5F;
-  background-color: #32323c;
-}
-
-WPushButton[value="1"]:hover {
-  border: 1px solid #4B4B4B;
-  background-color: #30303a;
-}
-
-/************************************************************************/
-/*     Deck                                                             */
-/************************************************************************/
-
 
 #Deck {
   border: 1px solid transparent;
@@ -102,16 +66,8 @@ WPushButton[value="1"]:hover {
   padding: 2px;
 }
 
-#DeckOverview {
-  margin: 50% 0;
-}
-
 #DeckTitle, #DeckTitleNote {
   font-size: 20px;
-}
-
-#DeckTitleNote {
-  margin: 0 2px;
 }
 
 #DeckChannelTitle, #DeckTrackTimeTitle, #DeckTempoTitle {
@@ -151,11 +107,7 @@ WPushButton[value="1"]:hover {
   qproperty-layoutAlignment: 'AlignHCenter | AlignTop';
 }
 
-/************************************************************************/
-/*     Effects                                                          */
-/************************************************************************/
-
-WEffectSelector {
+WEffectChainPresetSelector {
   background-color: transparent;
   color: #2d85cd;
   font-size: 14px;
@@ -188,9 +140,13 @@ WEffectSelector {
   font-weight: bold;
 }
 
-/************************************************************************/
-/*     Library                                                          */
-/************************************************************************/
+#DeckTitleNote {
+  margin: 0 2px;
+}
+
+#DeckOverview {
+  margin: 50% 0;
+}
 
 #LibraryWrapper QScrollBar {
   background-color: gray;
@@ -256,23 +212,13 @@ WEffectSelector {
   color: #e5e6ea;
 }
 
+#Mixxx {
+  background-color: black;
+}
+
 WLabel {
   color: #e5e6ea;
 }
-
-/* Library Search */
-#SearchBox {
-  background-color: #112f5c;
-  border-radius: 0;
-  font-size: 20px;
-  font-weight: bold;
-  padding: 4px;
-  text-transform: uppercase;
-}
-
-/************************************************************************/
-/*     BeatFX                                                           */
-/************************************************************************/
 
 #BeatFX_Container {
   border: 2px solid #32323c;
@@ -290,6 +236,39 @@ WLabel {
   text-transform: uppercase;
 }
 
+#Sampler {
+  background-color: #32323c;
+  border: 2px solid #d73535;
+  border-radius: 2px;
+  color: white;
+  font-size: 24px;
+  margin: 4px;
+  padding: 2px;
+}
+
+#Sampler[value="1"] {
+  background-color: #d73535;
+}
+
+#Sampler_Info {
+  color: white;
+  font-size: 10px;
+  margin: 4px;
+}
+
+#SamplersDeck1, #SamplersDeck2 {
+  margin: 0 4px;
+}
+
+#SearchBox {
+  background-color: #112f5c;
+  border-radius: 0;
+  font-size: 20px;
+  font-weight: bold;
+  padding: 4px;
+  text-transform: uppercase;
+}
+
 #SidebarContainer {
   background-color: #112f5c;
 }
@@ -303,10 +282,6 @@ WLabel {
   font-weight: bold;
   margin: 4px;
 }
-
-/************************************************************************/
-/*     Waveforms                                                        */
-/************************************************************************/
 
 #WaveformInfo {
   margin-right: 10px;
@@ -344,18 +319,6 @@ WLabel {
   padding: -6px -6px -3px -2px;
 }
 
-#WaveformInfo_KeylockButton {
-  image: url(skin:icons/keylock.svg) no-repeat center center;
-}
-
-#WaveformInfo_QuantizeButton {
-  image: url(skin:icons/quantize.svg) no-repeat center center;
-}
-
-/************************************************************************/
-/*     Tabs                                                             */
-/************************************************************************/
-
 #TabControls WPushButton {
   background-color: black;
   font-weight: bold;
@@ -372,32 +335,4 @@ WLabel {
 #TabControls WPushButton[value="1"] {
   border: 2px solid #c3d541;
   color: #c3d541;
-}
-
-/************************************************************************/
-/*     Samplers                                                         */
-/************************************************************************/
-
-#Sampler {
-  background-color: #32323c;
-  border: 2px solid #d73535;
-  border-radius: 2px;
-  color: white;
-  font-size: 24px;
-  margin: 4px;
-  padding: 2px;
-}
-
-#Sampler[value="1"] {
-  background-color: #d73535;
-}
-
-#Sampler_Info {
-  color: white;
-  font-size: 10px;
-  margin: 4px;
-}
-
-#SamplersDeck1, #SamplersDeck2 {
-  margin: 0 4px;
 }

--- a/waveform.xml
+++ b/waveform.xml
@@ -73,11 +73,67 @@
         <SignalLowColor>#007de1</SignalLowColor>
         <SignalMidColor>#007de1</SignalMidColor>
         <SignalHighColor>#007de1</SignalHighColor>
+	<DefaultMark>
+          <Align>bottom|right</Align>
+          <Color>#FF0000</Color>
+          <TextColor>#FFFFFF</TextColor>
+         <Text> %1 </Text>
+        </DefaultMark>
         <Mark>
           <Control>cue_point</Control>
           <Text>CUE</Text>
-          <Color>#eb870f</Color>
-          <TextColor>#eb870f</TextColor>
+          <Color>#ff6000</Color>
+          <TextColor>#ff6000</TextColor>
+          <Align>bottom</Align>
+        </Mark>
+        <Mark>
+          <Control>hotcue_1_position</Control>
+	  <Text></Text>
+          <Color>#ff6000</Color>
+          <TextColor>#00ff00</TextColor>
+          <Align>bottom</Align>
+        </Mark>
+        <Mark>
+          <Control>hotcue_2_position</Control>
+	  <Text></Text>
+          <Color>#ff6000</Color>
+          <TextColor>#00ff00</TextColor>
+          <Align>bottom</Align>
+        </Mark>
+        <Mark>
+          <Control>hotcue_3_position</Control>
+          <Color>#ff6000</Color>
+          <TextColor>#00ff00</TextColor>
+          <Align>bottom</Align>
+        </Mark>
+        <Mark>
+          <Control>hotcue_4_position</Control>
+          <Color>#ff6000</Color>
+          <TextColor>#00ff00</TextColor>
+          <Align>bottom</Align>
+        </Mark>
+        <Mark>
+          <Control>hotcue_5_position</Control>
+          <Color>#ff6000</Color>
+          <TextColor>#00ff00</TextColor>
+          <Align>bottom</Align>
+        </Mark>
+        <Mark>
+          <Control>hotcue_6_position</Control>
+          <Color>#ff6000</Color>
+          <TextColor>#00ff00</TextColor>
+          <Align>bottom</Align>
+        </Mark>
+        <Mark>
+          <Control>hotcue_7_position</Control>
+          <Color>#ff6000</Color>
+          <TextColor>#00ff00</TextColor>
+          <Align>bottom</Align>
+        </Mark>
+        <Mark>
+          <Control>hotcue_8_position</Control>
+          <Color>#ff6000</Color>
+          <TextColor>#00ff00</TextColor>
           <Align>bottom</Align>
         </Mark>
         <Mark>

--- a/waveform.xml
+++ b/waveform.xml
@@ -58,6 +58,29 @@
                   </Label>
                 </Children>
               </WidgetGroup>
+
+              <WidgetGroup>
+                <ObjectName>WaveformInfo_Controls</ObjectName>
+                <Layout>horizontal</Layout>
+                <Size>0me,30f</Size>
+                <Children>
+
+                  <Template src="skin:templates/toggle_button.xml">
+                    <SetVariable name="TooltipId">quantize</SetVariable>
+                    <SetVariable name="ObjectName">WaveformInfo_QuantizeButton</SetVariable>
+                    <SetVariable name="Size">30me,30f</SetVariable>
+                    <SetVariable name="LeftConnectionControl">[Channel<Variable name="channel"/>],quantize</SetVariable>
+                  </Template>
+
+                  <Template src="skin:templates/toggle_button.xml">
+                    <SetVariable name="TooltipId">keylock</SetVariable>
+                    <SetVariable name="ObjectName">WaveformInfo_KeylockButton</SetVariable>
+                    <SetVariable name="Size">30me,30f</SetVariable>
+                    <SetVariable name="LeftConnectionControl">[Channel<Variable name="channel"/>],keylock</SetVariable>
+                  </Template>
+
+                </Children>
+              </WidgetGroup>
             </Children>
           </WidgetGroup>
         </Children>

--- a/waveform.xml
+++ b/waveform.xml
@@ -4,13 +4,11 @@
     <Layout>horizontal</Layout>
     <Size>0me,50me</Size>
     <Children>
-
       <WidgetGroup>
         <ObjectName>WaveformInfo</ObjectName>
         <Layout>vertical</Layout>
         <Size>100f,0me</Size>
         <Children>
-
           <WidgetGroup>
             <ObjectName>WaveformInfo_Header</ObjectName>
             <Layout>horizontal</Layout>
@@ -26,25 +24,21 @@
               <BindProperty>highlight</BindProperty>
             </Connection>
           </WidgetGroup>
-
           <WidgetGroup>
             <ObjectName>WaveformInfo_Data_Container</ObjectName>
             <Layout>vertical</Layout>
-            <Size>0me,90me</Size>
+            <Size>0me,25me</Size>
             <Children>
-
               <WidgetGroup>
                 <ObjectName>WaveformInfo_Key_Container</ObjectName>
                 <Layout>horizontal</Layout>
                 <Size>0me,30f</Size>
                 <Children>
-
                   <Label>
                     <ObjectName>WaveformInfo_Key_Icon</ObjectName>
                     <Text>&#9837;&#9839;</Text>
                     <Style>color: black;</Style>
                   </Label>
-
                   <Key>
                     <ObjectName>WaveformInfo_Key</ObjectName>
                     <TooltipId>visual_key</TooltipId>
@@ -52,10 +46,8 @@
                       <ConfigKey>[Channel<Variable name="channel"/>],visual_key</ConfigKey>
                     </Connection>
                   </Key>
-
                 </Children>
               </WidgetGroup>
-
               <WidgetGroup>
                 <ObjectName>WaveformInfo_Bars_Container</ObjectName>
                 <Layout>horizontal</Layout>
@@ -63,40 +55,13 @@
                 <Children>
                   <Label>
                     <ObjectName>WaveformInfo_Bars</ObjectName>
-                    <Text>--.- Bars</Text>
                   </Label>
                 </Children>
               </WidgetGroup>
-
-              <WidgetGroup>
-                <ObjectName>WaveformInfo_Controls</ObjectName>
-                <Layout>horizontal</Layout>
-                <Size>0me,30f</Size>
-                <Children>
-
-                  <Template src="skin:templates/toggle_button.xml">
-                    <SetVariable name="TooltipId">quantize</SetVariable>
-                    <SetVariable name="ObjectName">WaveformInfo_QuantizeButton</SetVariable>
-                    <SetVariable name="Size">30me,30f</SetVariable>
-                    <SetVariable name="LeftConnectionControl">[Channel<Variable name="channel"/>],quantize</SetVariable>
-                  </Template>
-
-                  <Template src="skin:templates/toggle_button.xml">
-                    <SetVariable name="TooltipId">keylock</SetVariable>
-                    <SetVariable name="ObjectName">WaveformInfo_KeylockButton</SetVariable>
-                    <SetVariable name="Size">30me,30f</SetVariable>
-                    <SetVariable name="LeftConnectionControl">[Channel<Variable name="channel"/>],keylock</SetVariable>
-                  </Template>
-
-                </Children>
-              </WidgetGroup>
-
             </Children>
           </WidgetGroup>
-
         </Children>
       </WidgetGroup>
-
       <Visual>
         <TooltipId>waveform_display</TooltipId>
         <ObjectName>Waveform<Variable name="channel"/></ObjectName>
@@ -139,7 +104,6 @@
           <DisabledOpacity>0.4</DisabledOpacity>
         </MarkRange>
       </Visual>
-
     </Children>
   </WidgetGroup>
 </Template>


### PR DESCRIPTION
Hotcue display on preview and deck waveform with text (for example mixed in key 10 can add energy level info), color fx and beat fx support through effect chains. See my Pioneered-Plus repo for example Pioneer-style effect chains.