### PR TITLE
Add BPM range and BPM % display

### DIFF
--- a/deck.xml
+++ b/deck.xml
@@ -169,6 +169,46 @@
             </Children>
           </WidgetGroup>
           <WidgetGroup>
+            <ObjectName>TrackBPMRangeContainer</ObjectName>
+            <Layout>vertical</Layout>
+            <Size>65max,40max</Size>
+            <Children>              
+              <WidgetGroup>
+                <ObjectName>DeckBPMRangePercent</ObjectName>
+                <Size>30me,16f</Size>
+                <Layout>horizontal</Layout>
+                <Children>
+                  <Label>
+                    <ObjectName>BPMRangePlusMinus</ObjectName>
+                    <Text>&#177;</Text>
+                  </Label>
+                  <RateRange>
+                    <TooltipId>rate_range_display</TooltipId>
+                    <ObjectName>RateDisplay</ObjectName>
+                    <Channel><Variable name="channel" /></Channel>
+                    <Display>range</Display>
+                  </RateRange>
+                </Children>
+              </WidgetGroup>
+              <WidgetGroup>
+                <ObjectName>RateDisplay<Variable name="channel"/></ObjectName>
+                <Layout>horizontal</Layout>
+                <Size>0me,0me</Size>
+                <Children>
+                  <NumberRate>
+                    <TooltipId>rate_display</TooltipId>
+                    <Channel><Variable name="channel"/></Channel>
+                    <NumberOfDigits>1</NumberOfDigits>
+                  </NumberRate>
+                  <Label>
+                    <ObjectName>BPMPercent</ObjectName>
+                    <Text>%</Text>
+                  </Label>
+                </Children>
+              </WidgetGroup>
+            </Children>
+          </WidgetGroup>
+          <WidgetGroup>
             <ObjectName>TrackBPMContainer</ObjectName>
             <Layout>vertical</Layout>
             <Size>75max,0me</Size>

--- a/style.qss
+++ b/style.qss
@@ -97,6 +97,21 @@ WPushButton[value="1"]:hover {
   font-weight: bold;
 }
 
+#TrackBPMRangeContainer {
+  padding: 5px;
+  qproperty-layoutAlignment: 'AlignHCenter | AlignTop';
+}
+
+#DeckBPMRangePercent {
+  background-color: #222222;
+  padding: 0px;
+}
+
+#BPMRangePlusMinus, #RateDisplay {
+    font-size: 12px;
+    font-weight: bold;
+}
+
 #DeckHeader {
   background-color: #112f5c;
   padding: 2px;


### PR DESCRIPTION
See screenshot below. The BPM range and % display are neither the prettiest nor the most space-efficient, but they do the job.

![2022-05-03-083213_800x480_scrot](https://user-images.githubusercontent.com/8470756/166413357-7923ca55-1fe0-4471-b644-9cef8148e56f.png)
