### PR TITLE
add beat loop size indicator

### DIFF
--- a/style.qss
+++ b/style.qss
@@ -372,7 +372,8 @@ WLabel {
 
 #WaveformInfo_Data_Container,
 #WaveformInfo_Key_Container,
-#WaveformInfo_Bars_Container {
+#WaveformInfo_Bars_Container,
+#WaveformInfo_Loopsize_Container {
   qproperty-layoutAlignment: 'AlignLeft | AlignTop';
 }
 
@@ -382,6 +383,35 @@ WLabel {
   font-size: 14px;
   margin: 4px;
   padding: -6px -6px -3px -2px;
+}
+
+#WaveformInfo_Loop_Icon {
+  color: white;
+  font-size: 20px;
+  font-weight: bold;
+  margin: 2px;
+}
+
+#WaveformInfo_BeatloopSizeSpinBox {
+  margin: 3px;
+  padding: -4px -4px 0px -8px;
+}
+
+WBeatSpinBox {
+  color: #ffffff;
+  font-size: 14px;
+  font-weight: bold;
+  background-color: #000000;
+}
+
+WBeatSpinBox::down-arrow,
+WBeatSpinBox::up-arrow,
+WBeatSpinBox::down-button,
+WBeatSpinBox::up-button {
+  width: 0px;
+  height: 0px;
+  color: #000000;
+  background-color: #000000;
 }
 
 #WaveformInfo_KeylockButton {

--- a/waveform.xml
+++ b/waveform.xml
@@ -58,7 +58,23 @@
                   </Label>
                 </Children>
               </WidgetGroup>
-
+              <WidgetGroup>
+                <ObjectName>WaveformInfo_Loopsize_Container</ObjectName>
+                <Layout>horizontal</Layout>
+                <Size>0me,25f</Size>
+                <SetVariable name="beatloop_size_chan">[Channel<Variable name="channel"/>], beatloop_size</SetVariable>
+                <Children>
+                  <Label>
+                    <ObjectName>WaveformInfo_Loop_Icon</ObjectName>
+                    <Text>&#8635;</Text>
+                  </Label>
+                  <BeatSpinBox>
+                    <ObjectName>WaveformInfo_BeatloopSizeSpinBox</ObjectName>
+                    <TooltipId>beatloop_size</TooltipId>
+                    <Value>[Channel<Variable name="channel"/>],beatloop_size</Value>
+                  </BeatSpinBox>
+                </Children>
+              </WidgetGroup>
               <WidgetGroup>
                 <ObjectName>WaveformInfo_Controls</ObjectName>
                 <Layout>horizontal</Layout>


### PR DESCRIPTION
Implements https://github.com/timewasternl/Pioneered/issues/20

For the loop icon, I selected [unicode 8635](https://www.codetable.net/decimal/8635), it's not the prettiest loop sign, but I tried other codes higher than 10000 and they weren't displayed on raspberry pi.

![Screenshot from 2024-09-06 11-35-25](https://github.com/user-attachments/assets/48e27720-8a63-4e96-a2c0-a00a5f4945b6)

